### PR TITLE
Employee Test Notes

### DIFF
--- a/chp11/employee.py
+++ b/chp11/employee.py
@@ -10,25 +10,28 @@ class Employee:
 		self.first = first
 		self.last = last
 		self.salary = salary
-		self.default_raise = 5000
 
 	def format_name_salary(self):
 		"""Neatly formats full name and salary"""
 		full_name_salary = f"{self.first} {self.last} {self.salary}"
 		return full_name_salary.title()
 
-	def give_raise(self, custom_raise):
+	def give_raise(self, raise_amount = 5000):
 		"""Adds $5,000 as raise to salary by default, or allows the entry of custom raise amount"""
-		if int(custom_raise) > self.default_raise:
-			new_salary = self.salary + int(custom_raise)
-		else:
-			new_salary = self.salary + self.default_raise
-		print(f"Your new salary is now {new_salary}")		
 
-my_employee = Employee('Justin', 'Williams', 80000)
-print(my_employee.format_name_salary())
-input_raise = input("Please enter a raise amount: ")
-my_employee.give_raise(input_raise)
+		# This method should only have the responsibility of adding the employee's salary to the raise argument
+		# No printing of data should be done here. The format_name_salary_method already can print the salary
+		# NOTE: Can't use "raise" as a parameter name because it is a Python keywword for throwing an exception.
+		self.salary += int(raise_amount)
+	
+# The following code needs to be commented our for the test to "work". 
+# This is a good indication the following code could be a separate file. Typically
+# Each class will have its own file and you main program logic will "live" away from it.
+
+# my_employee = Employee('Justin', 'Williams', 80000)
+# print(my_employee.format_name_salary())
+# input_raise = input("Please enter a raise amount: ")
+# my_employee.give_raise(input_raise)
 
 
 

--- a/chp11/test_employee.py
+++ b/chp11/test_employee.py
@@ -19,7 +19,7 @@ class TestEmployee(unittest.TestCase):
 		"""Tests if name and salary are formatted corrctly"""
 
 		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
-		my_employee = Employee('justin', 'williams', 80000)
+		my_employee = Employee('justin', 'williams', 80_000)
 		
 		# The assertion that the `format_name_salary()` outputs what you expect for the above class
 		self.assertEqual(my_employee.format_name_salary(), 'Justin Williams 80000')
@@ -28,20 +28,31 @@ class TestEmployee(unittest.TestCase):
 		"""Tests if default raise works"""
 
 		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
-		my_employee = Employee('justin', 'williams', 80000)		
-
+		my_employee = Employee('justin', 'williams', 80_000)		
+		my_employee.give_raise()
 		# The assertion that the `format_name_salary()` outputs what you expect for the above class
-		self.assertEqual(my_employee.give_raise(), 'Your new salary is now 85000')
+		self.assertEqual(my_employee.salary, 85_000)
 
 
-	def gest_give_custom_raise(self):
+	def test_give_custom_raise(self):
 		"""Tests if entering custom raise works"""
 
 		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
-		my_employee = Employee('justin', 'williams', 80000)
-
+		my_employee = Employee('justin', 'williams', 80_000)
+		my_employee.give_raise(12345)
 		# The assertion that the `format_name_salary()` outputs what you expect for the above class
-		self.assertEqual(my_employee.give_raise(10000), 'Your new salary is now 85000')
+		self.assertEqual(my_employee.salary, 92_345)
+
+	def test_give_custom_raise_multiple_times(self):
+		"""Tests if entering custom raise works"""
+
+		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
+		my_employee = Employee('justin', 'williams', 80_000)
+		my_employee.give_raise()
+		my_employee.give_raise(12345)
+		my_employee.give_raise(0)
+		# The assertion that the `format_name_salary()` outputs what you expect for the above class
+		self.assertEqual(my_employee.salary, 97_345)
 
 if __name__ == '__main__':
     unittest.main()

--- a/chp11/test_employee.py
+++ b/chp11/test_employee.py
@@ -17,22 +17,31 @@ class TestEmployee(unittest.TestCase):
 
 	def test_format_name_salary(self):
 		"""Tests if name and salary are formatted corrctly"""
+
+		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
 		my_employee = Employee('justin', 'williams', 80000)
-		my_employee.format_name_salary()
+		
+		# The assertion that the `format_name_salary()` outputs what you expect for the above class
 		self.assertEqual(my_employee.format_name_salary(), 'Justin Williams 80000')
 
 	def test_give_default_raise(self):
 		"""Tests if default raise works"""
-		my_employee = Employee('justin', 'williams', 80000)
-		my_employee.give_raise()
+
+		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
+		my_employee = Employee('justin', 'williams', 80000)		
+
+		# The assertion that the `format_name_salary()` outputs what you expect for the above class
 		self.assertEqual(my_employee.give_raise(), 'Your new salary is now 85000')
 
 
 	def gest_give_custom_raise(self):
 		"""Tests if entering custom raise works"""
+
+		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
 		my_employee = Employee('justin', 'williams', 80000)
-		my_employee.give_raise()
-		self.assertEqual(input_raise.give_raise(), 90000)
+
+		# The assertion that the `format_name_salary()` outputs what you expect for the above class
+		self.assertEqual(my_employee.give_raise(10000), 'Your new salary is now 85000')
 
 if __name__ == '__main__':
     unittest.main()

--- a/chp11/test_employee.py
+++ b/chp11/test_employee.py
@@ -28,9 +28,13 @@ class TestEmployee(unittest.TestCase):
 		"""Tests if default raise works"""
 
 		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
-		my_employee = Employee('justin', 'williams', 80_000)		
+		my_employee = Employee('justin', 'williams', 80_000)	
+
+		# Increase the salary for that one employee. This method does not return anything.
+		# It "mutates" the salary for the above instance of the class.	
 		my_employee.give_raise()
-		# The assertion that the `format_name_salary()` outputs what you expect for the above class
+
+		# The assertion that the salary property outputs what you expect for the above class
 		self.assertEqual(my_employee.salary, 85_000)
 
 
@@ -39,19 +43,27 @@ class TestEmployee(unittest.TestCase):
 
 		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
 		my_employee = Employee('justin', 'williams', 80_000)
+
+		# Increase the salary for that one employee. This method does not return anything.
+		# It "mutates" the salary for the above instance of the class.	
 		my_employee.give_raise(12345)
-		# The assertion that the `format_name_salary()` outputs what you expect for the above class
+
+		# The assertion that the salary property outputs what you expect for the above class
 		self.assertEqual(my_employee.salary, 92_345)
 
 	def test_give_custom_raise_multiple_times(self):
-		"""Tests if entering custom raise works"""
+		"""Tests if entering custom raise works multiple times"""
 
 		# Set up the object you want to test, in this case, a new Employee with first name, last name, and salary
 		my_employee = Employee('justin', 'williams', 80_000)
+
+		# Increase the salary for that one employee. This method does not return anything.
+		# It "mutates" the salary for the above instance of the class.	
 		my_employee.give_raise()
 		my_employee.give_raise(12345)
 		my_employee.give_raise(0)
-		# The assertion that the `format_name_salary()` outputs what you expect for the above class
+
+		# The assertion that the salary property outputs what you expect for the above class
 		self.assertEqual(my_employee.salary, 97_345)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added some comments and re-formatted the code.

To run tests for this file, you must be inside  the `chp11` folder so you have access to `employee.py` and `test_employee.py`.

**Terminal Command**

`python3 -m unittest test_employee`

## employee.py
- Changed so it can pass the test suite
- refactor `give_raise()` so it can use the default raise amount or any amount passed in. It now only adds the raise to the salary and no longer prints.

## test_employee.py
- Change tests to assert class behavior.